### PR TITLE
roboquant library support

### DIFF
--- a/roboquant.json
+++ b/roboquant.json
@@ -1,0 +1,16 @@
+{
+  "description": "Algorithmic trading platform for Kotlin",
+  "link": "https://roboquant.org",
+  "properties": {
+    "v": "0.8-SNAPSHOT"
+  },
+  "repositories": [
+    "https://roboquant.jfrog.io/artifactory/roboquant"
+  ],
+  "dependencies": [
+    "org.roboquant:roboquant-core:$v",
+    "org.roboquant:roboquant-extra:$v",
+    "org.roboquant:roboquant-crypto:$v"
+  ]
+}
+


### PR DESCRIPTION
File for adding support for the roboquant library in Kotlin kernels. Roboquant is algo trading framework written in Kotlin and also has nice support for Notebooks. 

This is just to enable %use roboquant and find the right libraries. The rest of the heavy lifting is done in the library itself using the Jupyter Integration approach.