### PR TITLE
Add descriptor for gradle-enterprise-api-kotlin

### DIFF
--- a/gradle-enterprise-api-kotlin.json
+++ b/gradle-enterprise-api-kotlin.json
@@ -1,0 +1,14 @@
+{
+  "description": "A library to use the Gradle Enterprise API in Kotlin scripts or projects",
+  "properties": {
+    "version": "0.14.0"
+  },
+  "link": "https://github.com/gabrielfeo/gradle-enterprise-api-kotlin",
+  "dependencies": [
+    "com.github.gabrielfeo:gradle-enterprise-api-kotlin:$version"
+  ],
+  "imports": [
+    "com.gabrielfeo.gradle.enterprise.api.*",
+    "com.gabrielfeo.gradle.enterprise.api.model.*"
+   ]
+}


### PR DESCRIPTION
Add descriptor for [gabrielfeo/gradle-enterprise-api-kotlin](gabrielfeo/gradle-enterprise-api-kotlin). The library is useful for processing data from the Gradle Enterprise API in a Jupyter notebook.

I've tested the descriptor by using a [copy][1] in a notebook:

<img width="941" alt="Screenshot 2023-03-14 at 20 08 07" src="https://user-images.githubusercontent.com/25730717/225124912-d1d5763a-b5b5-4776-88bc-c0f3a0cc717c.png">

[1]: https://raw.githubusercontent.com/gabrielfeo/gradle-enterprise-api-kotlin/6bb80ebf8c46e9a4f5136df1db0b690ba6b07e54/gradle-enterprise-api-kotlin.json