### PR TITLE
Configure Renovate to update descriptor dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,52 @@
+{
+  "enabled": true,
+  "extends": [
+    "group:recommended",
+    "workarounds:all"
+  ],
+  "dependencyDashboard": "true",
+  "branchConcurrentLimit": 0,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "matchDatasources": ["maven"],
+      // Every repository from every descriptor
+      "registryUrls": [
+        // Default kernel repositories
+        "https://repo.maven.apache.org/maven2/",
+        "https://jitpack.io/",
+        // Custom repositories from descriptors must be added here
+        "https://oss.sonatype.org/service/local/repo_groups/public/content",
+        "https://repo.osgeo.org/repository/release",
+        "https://repo.kotlin.link",
+        "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers",
+        "https://s01.oss.sonatype.org/content/repositories/snapshots",
+        "https://packages.jetbrains.team/maven/p/kds/kotlin-ds-maven",
+      ]
+    }
+  ],
+  "regexManagers": [
+    // Matches dependencies with hardcoded versions (no interpolated properties)
+    {
+      "datasourceTemplate": "maven",
+      "versioningTemplate": "maven",
+      "fileMatch": [".*\\.json5"],
+      "matchStrings": [
+        // https://regex101.com/r/mex9HU/1
+        '^\\s*"(?<depName>[^":\\$]+:[^":\\$]+):(?<currentValue>[^":\\$]+)"',
+      ]
+    },
+    // Matches properties having a "*-renovate-hint" property below them with value "update: package=group:artifact"
+    {
+      "datasourceTemplate": "maven",
+      "versioningTemplate": "maven",
+      "fileMatch": [".*\\.json"],
+      "matchStrings": [
+        // https://regex101.com/r/7ESmC8/6
+        '(?:{ *"name": *)?".+?"[:,] *(?:"value": *)?"(?<currentValue>.+?)"(?: *})?,\\s*(?:{ *"name": *)?"\\S+-renovate-hint"[:,] *(?:"value": *)?"update: +package=(?<depName>\\S+?)"',
+      ]
+    },
+  ],
+}

--- a/biokotlin.json
+++ b/biokotlin.json
@@ -1,8 +1,9 @@
 {
   "description": "BioKotlin aims to be a high-performance bioinformatics library that brings the power and speed of compiled programming languages to scripting and big data environments.",
-  "properties": {
-    "v": "0.06"
-  },
+  "properties": [
+    { "name": "v", "value": "0.06" },
+    { "name": "v-renovate-hint", "value": "update: package=org.biokotlin:biokotlin" }
+  ],
   "link": "https://bitbucket.org/bucklerlab/biokotlin",
   "dependencies": [
     "org.biokotlin:biokotlin:$v"

--- a/combinatoricskt.json
+++ b/combinatoricskt.json
@@ -1,8 +1,9 @@
 {
   "description": "A combinatorics library for Kotlin",
-  "properties": {
-    "v": "1.6.0"
-  },
+  "properties": [
+    { "name": "v", "value": "1.6.0" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.shiguruikai:combinatoricskt" }
+  ],
   "link": "https://github.com/shiguruikai/combinatoricskt",
   "dependencies": [
     "com.github.shiguruikai:combinatoricskt:$v"

--- a/coroutines.json
+++ b/coroutines.json
@@ -1,8 +1,9 @@
 {
   "description": "Asynchronous programming and reactive streams support",
-  "properties": {
-    "v": "1.5.2"
-  },
+  "properties": [
+    { "name": "v", "value": "1.5.2" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kotlinx-coroutines-core" }
+  ],
   "link": "https://github.com/Kotlin/kotlinx.coroutines",
   "dependencies": [
     "org.jetbrains.kotlinx:kotlinx-coroutines-core:$v"

--- a/dataframe.json
+++ b/dataframe.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin framework for structured data processing",
-  "properties": {
-    "v": "0.10.0"
-  },
+  "properties": [
+    { "name": "v", "value": "0.10.0" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:dataframe" }
+  ],
   "repositories": [
     "https://oss.sonatype.org/service/local/repo_groups/public/content"
   ],

--- a/datetime.json
+++ b/datetime.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin date/time library",
-  "properties": {
-    "v": "0.4.0"
-  },
+  "properties": [
+    { "name": "v", "value": "0.4.0" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kotlinx-datetime" }
+  ],
   "link": "https://github.com/Kotlin/kotlinx-datetime",
   "dependencies": [
     "org.jetbrains.kotlinx:kotlinx-datetime-jvm:$v"

--- a/deeplearning4j-cuda.json
+++ b/deeplearning4j-cuda.json
@@ -1,11 +1,14 @@
 {
   "description": "Deep learning library for the JVM (CUDA support)",
-  "properties": {
-    "v": "1.0.0-beta6",
-    "cuda": "10.2",
-    "slf4j": "1.7.25",
-    "freemarker": "2.3.29"
-  },
+  "properties": [
+    { "name": "v", "value": "1.0.0-beta6" },
+    { "name": "v-renovate-hint", "value": "update: package=org.nd4j:nd4j-api" },
+    { "name": "cuda", "value": "10.2" },
+    { "name": "slf4j", "value": "1.7.25" },
+    { "name": "slf4j-renovate-hint", "value": "update: package=org.slf4j:slf4j-api" },
+    { "name": "freemarker", "value": "2.3.29" },
+    { "name": "freemarker-renovate-hint", "value": "update: package=org.freemarker:freemarker" }
+  ],
   "link": "https://github.com/eclipse/deeplearning4j",
   "dependencies": [
     "org.freemarker:freemarker:$freemarker",

--- a/deeplearning4j.json
+++ b/deeplearning4j.json
@@ -1,10 +1,13 @@
 {
   "description": "Deep learning library for the JVM",
-  "properties": {
-    "v": "1.0.0-beta6",
-    "slf4j": "1.7.25",
-    "freemarker": "2.3.29"
-  },
+  "properties": [
+    { "name": "v", "value": "1.0.0-beta6" },
+    { "name": "v-renovate-hint", "value": "update: package=org.nd4j:nd4j-api" },
+    { "name": "slf4j", "value": "1.7.25" },
+    { "name": "slf4j-renovate-hint", "value": "update: package=org.slf4j:slf4j-api" },
+    { "name": "freemarker", "value": "2.3.29" },
+    { "name": "freemarker-renovate-hint", "value": "update: package=org.freemarker:freemarker" }
+  ],
   "link": "https://github.com/eclipse/deeplearning4j",
   "dependencies": [
     "org.freemarker:freemarker:$freemarker",

--- a/exposed.json
+++ b/exposed.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin SQL framework",
-  "properties": {
-    "v": "0.41.1"
-  },
+  "properties": [
+    { "name": "v", "value": "0.41.1" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.exposed:exposed-core" }
+  ],
   "link": "https://github.com/JetBrains/Exposed",
   "dependencies": [
     "org.jetbrains.exposed:exposed-core:$v",

--- a/fuel.json
+++ b/fuel.json
@@ -1,8 +1,9 @@
 {
   "description": "HTTP networking library",
-  "properties": {
-    "v": "2.3.1"
-  },
+  "properties": [
+    { "name": "v", "value": "2.3.1" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.kittinunf.fuel:fuel" }
+  ],
   "link": "https://github.com/kittinunf/fuel",
   "dependencies": [
     "com.github.kittinunf.fuel:fuel:$v",

--- a/gradle-enterprise-api-kotlin.json
+++ b/gradle-enterprise-api-kotlin.json
@@ -1,8 +1,9 @@
 {
   "description": "A library to use the Gradle Enterprise API in Kotlin scripts or projects",
-  "properties": {
-    "version": "0.14.0"
-  },
+  "properties": [
+    { "name": "version", "value": "0.14.0" },
+    { "name": "version-renovate-hint", "value": "update: package=com.github.gabrielfeo:gradle-enterprise-api-kotlin" }
+  ],
   "link": "https://github.com/gabrielfeo/gradle-enterprise-api-kotlin",
   "dependencies": [
     "com.github.gabrielfeo:gradle-enterprise-api-kotlin:$version"
@@ -10,5 +11,5 @@
   "imports": [
     "com.gabrielfeo.gradle.enterprise.api.*",
     "com.gabrielfeo.gradle.enterprise.api.model.*"
-   ]
+  ]
 }

--- a/gral.json
+++ b/gral.json
@@ -1,8 +1,9 @@
 {
   "description": "Java library for displaying plots",
-  "properties": {
-    "v": "0.11"
-  },
+  "properties": [
+    { "name": "v", "value": "0.11" },
+    { "name": "v-renovate-hint", "value": "update: package=de.erichseifert.gral:gral-core" }
+  ],
   "link": "https://github.com/eseifert/gral",
   "dependencies": [
     "de.erichseifert.gral:gral-core:$v"

--- a/jdsp.json
+++ b/jdsp.json
@@ -1,8 +1,9 @@
 {
   "description": "Java library for signal processing",
-  "properties": {
-    "v": "0.5.1"
-  },
+  "properties": [
+    { "name": "v", "value": "0.5.1" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.psambit9791:jdsp" }
+  ],
   "link": "https://github.com/psambit9791/jDSP",
   "dependencies": [
     "com.github.psambit9791:jdsp:$v"

--- a/kalasim.json
+++ b/kalasim.json
@@ -1,8 +1,9 @@
 {
   "description": "Discrete event simulator",
-  "properties": {
-    "v": "0.7.92"
-  },
+  "properties": [
+    { "name": "v", "value": "0.7.92" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.holgerbrandl:kalasim" }
+  ],
   "link": "https://www.kalasim.org",
   "dependencies": [
     "com.github.holgerbrandl:kalasim:$v"

--- a/kandy-echarts.json
+++ b/kandy-echarts.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin plotting DSL for Apache ECharts",
-  "properties": {
-    "kandyVersion": "0.4.1"
-  },
+  "properties": [
+    { "name": "kandyVersion", "value": "0.4.1" },
+    { "name": "kandyVersion-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kandy-echarts" }
+  ],
   "link": "https://github.com/Kotlin/kandy",
   "dependencies": [
     "org.jetbrains.kotlinx:kandy-echarts:$kandyVersion"

--- a/kandy.json
+++ b/kandy.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin plotting DSL for Lets-Plot",
-  "properties": {
-    "kandyVersion": "0.4.1"
-  },
+  "properties": [
+    { "name": "kandyVersion", "value": "0.4.1" },
+    { "name": "kandyVersion-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kandy-lets-plot" }
+  ],
   "link": "https://github.com/Kotlin/kandy",
   "dependencies": [
     "org.jetbrains.kotlinx:kandy-lets-plot:$kandyVersion"

--- a/khttp.json
+++ b/khttp.json
@@ -1,8 +1,9 @@
 {
   "description": "HTTP networking library",
-  "properties": {
-    "v": "39f76b4186"
-  },
+  "properties": [
+    { "name": "v", "value": "39f76b4186" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.jkcclemens:khttp" }
+  ],
   "link": "https://github.com/jkcclemens/khttp",
   "repositories": [
     "https://jitpack.io"

--- a/klaxon.json
+++ b/klaxon.json
@@ -1,8 +1,9 @@
 {
   "description": "JSON parser for Kotlin",
-  "properties": {
-    "v": "5.5"
-  },
+  "properties": [
+    { "name": "v", "value": "5.5" },
+    { "name": "v-renovate-hint", "value": "update: package=com.beust:klaxon" }
+  ],
   "link": "https://github.com/cbeust/klaxon",
   "dependencies": [
     "com.beust:klaxon:$v"

--- a/kmath.json
+++ b/kmath.json
@@ -1,8 +1,9 @@
 {
   "description": "Experimental Kotlin algebra-based mathematical library",
-  "properties": {
-    "v": "0.3.0"
-  },
+  "properties": [
+    { "name": "v", "value": "0.3.0" },
+    { "name": "v-renovate-hint", "value": "update: package=space.kscience:kmath-jupyter" }
+  ],
   "link": "https://github.com/mipt-npm/kmath",
   "repositories": [
     "https://repo.kotlin.link"

--- a/kotlin-dl.json
+++ b/kotlin-dl.json
@@ -1,9 +1,10 @@
 {
   "description": "KotlinDL library which provides Keras-like API for deep learning",
   "link": "https://github.com/Kotlin/kotlindl",
-  "properties": {
-    "v": "0.5.1"
-  },
+  "properties": [
+    { "name": "v", "value": "0.5.1" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kotlin-deeplearning-api" }
+  ],
   "dependencies": [
     "org.jetbrains.kotlinx:kotlin-deeplearning-api:$v",
     "org.jetbrains.kotlinx:kotlin-deeplearning-impl:$v",

--- a/kotlin-statistics.json
+++ b/kotlin-statistics.json
@@ -1,8 +1,9 @@
 {
   "description": "Idiomatic statistical operators for Kotlin",
-  "properties": {
-    "v": "-SNAPSHOT"
-  },
+  "properties": [
+    { "name": "v", "value": "-SNAPSHOT" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.thomasnield:kotlin-statistics" }
+  ],
   "link": "https://github.com/thomasnield/kotlin-statistics",
   "dependencies": [
     "com.github.thomasnield:kotlin-statistics:$v"

--- a/krangl.json
+++ b/krangl.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin DSL for data wrangling",
-  "properties": {
-    "v": "0.17"
-  },
+  "properties": [
+    { "name": "v", "value": "0.17" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.holgerbrandl:krangl" }
+  ],
   "link": "https://github.com/holgerbrandl/krangl",
   "dependencies": [
     "com.github.holgerbrandl:krangl:$v"

--- a/kravis.json
+++ b/kravis.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin grammar for data visualization",
-  "properties": {
-    "v": "0.8.1"
-  },
+  "properties": [
+    { "name": "v", "value": "0.8.1" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.holgerbrandl:kravis" }
+  ],
   "link": "https://github.com/holgerbrandl/kravis",
   "dependencies": [
     "com.github.holgerbrandl:kravis:$v"

--- a/lets-plot-dataframe.json
+++ b/lets-plot-dataframe.json
@@ -1,9 +1,10 @@
 {
   "description": "A bridge between Lets-Plot and dataframe libraries",
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
-  "properties": {
-    "v": "0.0.14-dev-15-0.11.0.44"
-  },
+  "properties": [
+    { "name": "v", "value": "0.0.14-dev-15-0.11.0.44" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:lets-plot-dsl" }
+  ],
   "repositories": [
     "https://oss.sonatype.org/service/local/repo_groups/public/content"
   ],

--- a/lets-plot-gt.json
+++ b/lets-plot-gt.json
@@ -1,10 +1,12 @@
 {
   "description": "Lets-Plot visualisation for GeoTools toolkit",
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
-  "properties": {
-    "api": "4.3.0",
-    "gt": "[23,)"
-  },
+  "properties": [
+    { "name": "api", "value": "4.3.0" },
+    { "name": "api-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-kotlin-geotools" },
+    { "name": "gt", "value": "[23,)" },
+    { "name": "gt-renovate-hint", "value": "update: package=org.geotools:gt-geojson" }
+  ],
   "repositories": [
     "https://repo.osgeo.org/repository/release"
   ],

--- a/lets-plot.json
+++ b/lets-plot.json
@@ -1,11 +1,13 @@
 {
   "description": "ggplot-like interactive visualization for Kotlin",
-  "properties": {
-    "api": "4.3.0",
-    "lib": "3.1.0",
-    "js": "3.1.0",
-    "isolatedFrame": ""
-  },
+  "properties": [
+    { "name": "api", "value": "4.3.0" },
+    { "name": "api-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-kotlin-kernel" },
+    { "name": "lib", "value": "3.1.0" },
+    { "name": "lib-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-common" },
+    { "name": "js", "value": "3.1.0" },
+    { "name": "isolatedFrame", "value": "" }
+  ],
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
   "dependencies": [
     "org.jetbrains.lets-plot:lets-plot-kotlin-kernel:$api",

--- a/lib-ext.json
+++ b/lib-ext.json
@@ -1,8 +1,8 @@
 {
   "description": "Extended functionality for Jupyter kernel",
-  "properties": {
-    "v": "$kernelMavenVersion"
-  },
+  "properties": [
+    { "name": "v", "value": "$kernelMavenVersion" }
+  ],
   "link": "https://github.com/Kotlin/kotlin-jupyter",
   "dependencies": [
     "org.jetbrains.kotlinx:kotlin-jupyter-lib-ext:$v"

--- a/londogard-nlp-toolkit.json
+++ b/londogard-nlp-toolkit.json
@@ -1,9 +1,10 @@
 {
   "description": "A Natural Language Processing (NLP) toolkit for Kotlin on the JVM",
   "link": "https://github.com/londogard/londogard-nlp-toolkit",
-  "properties": {
-    "v": "v1.0.0"
-  },
+  "properties": [
+    { "name": "v", "value": "v1.0.0" },
+    { "name": "v-renovate-hint", "value": "update: package=com.londogard:londogard-nlp-toolkit" }
+  ],
   "repositories": [
     "https://jitpack.io"
   ],

--- a/multik.json
+++ b/multik.json
@@ -1,8 +1,9 @@
 {
   "description": "Multidimensional array library for Kotlin",
-  "properties": {
-    "v": "0.2.1"
-  },
+  "properties": [
+    { "name": "v", "value": "0.2.1" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:multik-core-jvm" }
+  ],
   "link": "https://github.com/Kotlin/multik",
   "dependencies": [
     "org.jetbrains.kotlinx:multik-core-jvm:$v",

--- a/mysql.json
+++ b/mysql.json
@@ -1,8 +1,9 @@
 {
   "description": "MySql JDBC Connector",
-  "properties": {
-    "v": "8.0.17"
-  },
+  "properties": [
+    { "name": "v", "value": "8.0.17" },
+    { "name": "v-renovate-hint", "value": "update: package=mysql:mysql-connector-java" }
+  ],
   "link": "https://github.com/mysql/mysql-connector-j",
   "dependencies": [
     "mysql:mysql-connector-java:$v"

--- a/openai.json
+++ b/openai.json
@@ -1,8 +1,9 @@
 {
   "description": "OpenAI API for Jupyter Notebooks",
-  "properties": {
-    "version": "0.1.0"
-  },
+  "properties": [
+    { "name": "version", "value": "0.1.0" },
+    { "name": "version-renovate-hint", "value": "update: package=org.jetbrains.kotlin.ds:kotlin-openai" }
+  ],
   "link": "https://openai.com/blog/chatgpt",
   "repositories": [
     "https://packages.jetbrains.team/maven/p/kds/kotlin-ds-maven"

--- a/plotly-server.json
+++ b/plotly-server.json
@@ -1,8 +1,9 @@
 {
   "description": "[beta] Plotly.kt jupyter integration for dynamic plots.",
-  "properties": {
-    "v": "0.4.0"
-  },
+  "properties": [
+    { "name": "v", "value": "0.4.0" },
+    { "name": "v-renovate-hint", "value": "update: package=space.kscience:plotlykt-server" }
+  ],
   "link": "https://github.com/mipt-npm/plotly.kt",
   "repositories": [
     "https://repo.kotlin.link",

--- a/plotly.json
+++ b/plotly.json
@@ -1,8 +1,9 @@
 {
   "description": "[beta] Plotly.kt jupyter integration for static plots.",
-  "properties": {
-    "v": "0.5.0"
-  },
+  "properties": [
+    { "name": "v", "value": "0.5.0" },
+    { "name": "v-renovate-hint", "value": "update: package=space.kscience:plotlykt-jupyter" }
+  ],
   "link": "https://github.com/mipt-npm/plotly.kt",
   "repositories": [
     "https://repo.kotlin.link",

--- a/rdkit.json
+++ b/rdkit.json
@@ -1,8 +1,9 @@
 {
   "description": "Open-Source Cheminformatics Software",
-  "properties": {
-    "v": "1.0.0"
-  },
+  "properties": [
+    { "name": "v", "value": "1.0.0" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:rdkit-jupyter" }
+  ],
   "link": "https://www.rdkit.org/",
   "dependencies": [
     "org.jetbrains.kotlinx:rdkit-jupyter:$v"

--- a/roboquant.json
+++ b/roboquant.json
@@ -1,9 +1,10 @@
 {
   "description": "Algorithmic trading platform written in Kotlin",
   "link": "https://roboquant.org",
-  "properties": {
-    "version": "1.3.0"
-  },
+  "properties": [
+    { "name": "version", "value": "1.3.0" },
+    { "name": "version-renovate-hint", "value": "update: package=org.roboquant:roboquant-jupyter" }
+  ],
   "repositories": [
     "https://s01.oss.sonatype.org/content/repositories/snapshots"
   ],

--- a/serialization.json
+++ b/serialization.json
@@ -1,8 +1,9 @@
 {
   "description": "Kotlin multi-format reflection-less serialization",
-  "properties": {
-    "v": "1.3.2"
-  },
+  "properties": [
+    { "name": "v", "value": "1.3.2" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kotlinx-serialization-json" }
+  ],
   "link": "https://github.com/Kotlin/kotlinx.serialization",
   "dependencies": [
     "org.jetbrains.kotlinx:kotlinx-serialization-json:$v"

--- a/smile.json
+++ b/smile.json
@@ -1,8 +1,9 @@
 {
   "description": "Statistical Machine Intelligence and Learning Engine",
-  "properties": {
-    "v": "2.4.0"
-  },
+  "properties": [
+    { "name": "v", "value": "2.4.0" },
+    { "name": "v-renovate-hint", "value": "update: package=com.github.haifengl:smile-kotlin" }
+  ],
   "link": "https://github.com/haifengl/smile",
   "dependencies": [
     "com.github.haifengl:smile-kotlin:$v"

--- a/spark-streaming.json
+++ b/spark-streaming.json
@@ -1,12 +1,13 @@
 {
   "description": "Kotlin API for Apache Spark Streaming: scalable, high-throughput, fault-tolerant stream processing of live data streams",
-  "properties": {
-    "spark": "3.3.1",
-    "scala": "2.13",
-    "v": "1.2.3",
-    "displayLimit": "20",
-    "displayTruncate": "30"
-  },
+  "properties": [
+    { "name": "spark", "value": "3.3.1" },
+    { "name": "scala", "value": "2.13" },
+    { "name": "v", "value": "1.2.3" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx.spark:jupyter_3.3.1_2.13" },
+    { "name": "displayLimit", "value": "20" },
+    { "name": "displayTruncate", "value": "30" }
+  ],
   "link": "https://github.com/JetBrains/kotlin-spark-api",
   "dependencies": [
     "org.jetbrains.kotlinx.spark:jupyter_$spark_$scala:$v"

--- a/spark.json
+++ b/spark.json
@@ -1,14 +1,15 @@
 {
   "description": "Kotlin API for Apache Spark: unified analytics engine for large-scale data processing",
-  "properties": {
-    "spark": "3.3.1",
-    "scala": "2.13",
-    "v": "1.2.3",
-    "displayLimit": "20",
-    "displayTruncate": "30",
-    "spark.app.name": "Jupyter",
-    "spark.master": "local[*]"
-  },
+  "properties": [
+    { "name": "spark", "value": "3.3.1" },
+    { "name": "scala", "value": "2.13" },
+    { "name": "v", "value": "1.2.3" },
+    { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx.spark:jupyter_3.3.1_2.13" },
+    { "name": "displayLimit", "value": "20" },
+    { "name": "displayTruncate", "value": "30" },
+    { "name": "spark.app.name", "value": "Jupyter" },
+    { "name": "spark.master", "value": "local[*]" }
+  ],
   "link": "https://github.com/JetBrains/kotlin-spark-api",
   "dependencies": [
     "org.jetbrains.kotlinx.spark:jupyter_$spark_$scala:$v"

--- a/webtau.json
+++ b/webtau.json
@@ -1,8 +1,9 @@
 {
   "description": "WebTau end-to-end testing across layers",
-  "properties": {
-    "v": "1.53"
-  },
+  "properties": [
+    { "name": "v", "value": "1.53" },
+    { "name": "v-renovate-hint", "value": "update: package=org.testingisdocumenting.webtau:webtau" }
+  ],
   "link": "https://github.com/testingisdocumenting/webtau",
   "dependencies": [
     "org.testingisdocumenting.webtau:webtau:$v"


### PR DESCRIPTION
This PR configures [Renovate](https://github.com/renovatebot/renovate) to open PRs updating versions of library descriptor dependencies automatically, aiming to ease the burden on maintainers and contributors :) 

The end result can be seen in the fork:
- gabrielfeo/kotlin-jupyter-libraries#169
- Available updates: https://github.com/gabrielfeo/kotlin-jupyter-libraries/pulls

## Problem

Dependency descriptors are a good solution and easy to contribute to. However, the common issue of keeping dependencies up-to-date also applies to descriptor dependencies. As a result, when one wants to write a quick-and-dirty notebook today, without the need to pin versions, one gets very old versions of libraries. Pinning versions can be recommended for various reasons, but the default (no pinning) should bring in the latest version.

For example, the notebook below would fail to compile, because while `shutdown` was introduced in `1.6.0` (and the latest is `1.6.4`), the descriptor is still a minor behind at `1.5.2`.

```
%use coroutines
Dispatchers.shutdown()
```

There are other examples, like slf4j still at `1.7.25` while `2.0.7` is the latest.

## Solution

A Renovate config is added. Basically, descriptor properties which refer to a package's version now have a "hint property" below them stating on which package updating should be based on. 

```json
{
  "properties": {
    "v": "1.5.2",
    "v-renovate-hint": "update: package=org.jetbrains.kotlinx:kotlinx-coroutines-core"
  },
  "dependencies": [
    "org.jetbrains.kotlinx:kotlinx-coroutines-core:$v",
    "org.jetbrains.kotlinx:kotlinx-coroutines-extras:$v"
  ]
}
```

The Renovate config has a regex to parse such properties as long as it's immediately followed by a hint property, as well as any dependencies that hardcode versions without properties. More details in the config.

Hint properties are an alternative to comments, which aren't supported in JSON. Migrating to another format isn't feasible because it'd make descriptors incompatible with existing Kernel versions when `%useLatestDescriptors` is used.

### Behavior in old kernel versions

Usages of unnamed properties in notebooks together with `%useLatestDescriptors` in old versions of the Kernel (before [the Kernel was updated to disregard hint properties](https://github.com/Kotlin/kotlin-jupyter/commit/d9a890e62c40897533ab48b8fe4c42658d96d906)), will break for multiple-property overrides:

```diff
{ "name": "v", "value": "1.0" },
+{ "name": "v-renovate-hint", "value": "..." },
{ "name": "api", "value": "1.0" },
+{ "name": "api-renovate-hint", "value": "..." },
```

```
%useLatestDescriptors
// Broken
%use library(2.0, 2.1)
```

But unnamed overrides of single-property descriptors as below will still work, thanks to migrating all descriptors to the "ordered properties syntax":

```diff
-"v": "1.0",
+{ "name": "v", "value": "1.0" },
+{ "name": "v-renovate-hint", "value": "..." },
```

```
%useLatestDescriptors
// OK
%use library(2.0)
```

### Enabling Renovate

Renovate can either be activated [as a GitHub App](https://github.com/renovatebot/renovate/blob/main/docs/usage/getting-started/installing-onboarding.md) or [as a GitHub action](https://github.com/gabrielfeo/kotlin-jupyter-libraries/blob/e0e3cd3d8ad8aa1b7b313a66b79eb6eac7967e83/.github/workflows/renovate.yml). It works better as a GitHub app because it responds instantly when a PR checkbox is checked, just like Dependabot, but it'll probably require installation at the Kotlin org-level. If that's not possible, I can add the action to this PR, set to run in a schedule.