### PR TITLE
Make Renovate ignore unwanted versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,9 +10,9 @@
   "prHourlyLimit": 0,
   "rebaseWhen": "conflicted",
   "packageRules": [
+    // Define repositories
     {
       "matchDatasources": ["maven"],
-      // Every repository from every descriptor
       "registryUrls": [
         // Default kernel repositories
         "https://repo.maven.apache.org/maven2/",
@@ -25,7 +25,27 @@
         "https://s01.oss.sonatype.org/content/repositories/snapshots",
         "https://packages.jetbrains.team/maven/p/kds/kotlin-ds-maven",
       ]
-    }
+    },
+    // Ignore -dev versions, because in maven 1.0 < 1.0-dev
+    {
+      "matchPackagePatterns": [".*"],
+      "allowedVersions": "!/[-.]dev/",
+    },
+    // Allow -dev versions if it's already using one
+    {
+      "matchCurrentValue": "/[-.]dev/",
+      "allowedVersions": "/.*/",
+    },
+    // Ignore pushed by mistake version
+    {
+      "matchPackageNames": ["org.jetbrains.kotlinx:dataframe"],
+      "allowedVersions": "!/[-.]dev|^1548$/",
+    },
+    // Ignore pushed by mistake versions
+    {
+      "matchPackageNames": ["com.github.gabrielfeo:gradle-enterprise-api-kotlin"],
+      "allowedVersions": "!/^0\\.999.*$/",
+    },
   ],
   "regexManagers": [
     // Matches dependencies with hardcoded versions (no interpolated properties)


### PR DESCRIPTION
This PR configures Renovate to ignore 2 cases of unwanted versions, as a follow-up to #201.

## Changes

### 1. Ignore versions with a `-dev` qualifier

- #209
- #210 
- #218 
- #222

Renovate ignores unstable versions by default, but it perceives these as stable (verified by adding a `-dev` case to [this test][1]).

But also, it considers `-dev` versions the latest, e.g. for `plotlykt-jupyter` it chooses `0.5.3-dev-1` over `0.5.3`. It implements Maven version ordering strictly:

>**Non-numeric tokens ("qualifiers") have the alphabetical order**, except for the following tokens which come first in this order:
>"alpha" < "beta" < "milestone" < "rc" = "cr" < "snapshot" < "" = "final" = "ga" < "sp"
>https://maven.apache.org/pom.html#version-order-specification

It's clearer to see ordering rules in practice: https://gist.github.com/gabrielfeo/924682a4d6ef4b1b96c20d40d5fbe2d7

To fix it, a rule is added to ignore `-dev` for any dependency, except where is currently used `-dev` (a second rule, as later rules have precedence).

### 2. Ignore old test versions from specific libraries

- #212
- #225

This is necessary because since Renovates takes these as higher than the actual latest versions, and we close their update PRs, it won't open a new one until a higher v1549.0.0 is released, for example.

## Tests

Tested manually looking at logs in the [Renovate Dashboard][4] and the end result in the fork's dependency dashboard, which doesn't contain suggest versions anymore: 

- gabrielfeo/kotlin-jupyter-libraries#169

[1]: https://github.com/renovatebot/renovate/blob/77bd389582cbd725720721c847cb4aa451febc50/lib/modules/versioning/maven/index.spec.ts#L49
[2]: https://jitpack.io/com/github/gabrielfeo/gradle-enterprise-api-kotlin/maven-metadata.xml
[3]: https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/dataframe/maven-metadata.xml
[4]: https://app.renovatebot.com/dashboard