### PR TITLE
Update groupId of gradle-enterprise-api-kotlin

### DIFF
--- a/gradle-enterprise-api-kotlin.json
+++ b/gradle-enterprise-api-kotlin.json
@@ -1,12 +1,12 @@
 {
   "description": "A library to use the Gradle Enterprise API in Kotlin scripts or projects",
   "properties": [
-    { "name": "version", "value": "0.16.0" },
-    { "name": "version-renovate-hint", "value": "update: package=com.github.gabrielfeo:gradle-enterprise-api-kotlin" }
+    { "name": "version", "value": "0.16.2" },
+    { "name": "version-renovate-hint", "value": "update: package=com.gabrielfeo:gradle-enterprise-api-kotlin" }
   ],
   "link": "https://github.com/gabrielfeo/gradle-enterprise-api-kotlin",
   "dependencies": [
-    "com.github.gabrielfeo:gradle-enterprise-api-kotlin:$version"
+    "com.gabrielfeo:gradle-enterprise-api-kotlin:$version"
   ],
   "imports": [
     "com.gabrielfeo.gradle.enterprise.api.*",


### PR DESCRIPTION
It's been moved from JitPack to Maven Central under a new groupId. Also update version to the latest.