### PR TITLE
Add kt-math and 2p-kt

### DIFF
--- a/2p-kt.json
+++ b/2p-kt.json
@@ -1,0 +1,30 @@
+{
+    "description": "A Kotlin Multi-Platform ecosystem for symbolic AI",
+    "properties": [
+        {
+            "name": "v",
+            "value": "0.31.9"
+        },
+        {
+            "name": "v-renovate-hint",
+            "value": "update: package=it.unibo.tuprolog:full"
+        }
+    ],
+    "link": "https://github.com/gciatto/kt-math",
+    "repositories": [
+        "https://repo1.maven.org/maven2"
+    ],
+    "dependencies": [
+        "it.unibo.tuprolog:solve-classic-jvm:$v",
+        "it.unibo.tuprolog:parser-theory-jvm:$v",
+        "it.unibo.tuprolog:dsl-solve-jvm:$v"
+    ],
+    "imports": [
+        "it.unibo.tuprolog.core.*",
+        "it.unibo.tuprolog.unify.*",
+        "it.unibo.tuprolog.theory.*",
+        "it.unibo.tuprolog.solve.*",
+        "it.unibo.tuprolog.core.parsing.*",
+        "it.unibo.tuprolog.theory.parsing.*"
+    ]
+}

--- a/kt-math.json
+++ b/kt-math.json
@@ -1,0 +1,23 @@
+{
+    "description": "Kotlin multi-platform port of java.math.*",
+    "properties": [
+        {
+            "name": "v",
+            "value": "0.9.0"
+        },
+        {
+            "name": "v-renovate-hint",
+            "value": "update: package=io.github.gciatto:kt-math"
+        }
+    ],
+    "link": "https://github.com/gciatto/kt-math",
+    "repositories": [
+        "https://repo1.maven.org/maven2"
+    ],
+    "dependencies": [
+        "io.github.gciatto:kt-math-jvm:$v"
+    ],
+    "imports": [
+        "org.gciatto.kt.math.*"
+    ]
+}


### PR DESCRIPTION
Add `json` descriptors for the libraries mentioned in the title:
- [`2p-kt`](https://github.com/tuProlog/2p-kt): a Kotlin Multi-Platform ecosystem for symbolic AI 
- [`kt-math`](https://github.com/gciatto/kt-math): pure Kotlin porting of Java's BigIntegers and BigDecimals (along with `java.math.*`) 

(The latter is required to use the former)