### PR TITLE
Add develocity-api-kotlin (rename of gradle-enterprise-api-kotlin)

### DIFF
--- a/develocity-api-kotlin.json
+++ b/develocity-api-kotlin.json
@@ -1,0 +1,11 @@
+{
+  "description": "A library to use the Develocity API in Kotlin scripts or projects",
+  "properties": [
+    { "name": "version", "value": "2024.1.0" },
+    { "name": "version-renovate-hint", "value": "update: package=com.gabrielfeo:develocity-api-kotlin" }
+  ],
+  "link": "https://github.com/gabrielfeo/develocity-api-kotlin",
+  "dependencies": [
+    "com.gabrielfeo:develocity-api-kotlin:$version"
+  ]
+}

--- a/gradle-enterprise-api-kotlin.json
+++ b/gradle-enterprise-api-kotlin.json
@@ -1,5 +1,5 @@
 {
-  "description": "A library to use the Gradle Enterprise API in Kotlin scripts or projects",
+  "description": "[Deprecated: use develocity-api-kotlin] A library to use the Gradle Enterprise API in Kotlin scripts or projects",
   "properties": [
     { "name": "version", "value": "2023.3.1" },
     { "name": "version-renovate-hint", "value": "update: package=com.gabrielfeo:gradle-enterprise-api-kotlin" }


### PR DESCRIPTION
[It was announced that Gradle Enterprise would be renamed to Develocity](https://gradle.com/press-media/gradle-enterprise-is-now-develocity/) and the library is being renamed accordingly (gabrielfeo/gradle-enterprise-api-kotlin#184).

The old descriptor `gradle-enterprise-api-kotlin.json` is kept so that existing usages don't break.