### PR TITLE
Remove imports/init/renders from lets-plot descriptors (move to Integ…

### DIFF
--- a/lets-plot-gt.json
+++ b/lets-plot-gt.json
@@ -3,15 +3,13 @@
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
   "properties": [
     { "name": "api", "value": "4.8.0" },
-    { "name": "api-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-kotlin-geotools" },
-    { "name": "gt", "value": "[30,)" },
-    { "name": "gt-renovate-hint", "value": "update: package=org.geotools:gt-geojson" }
+    { "name": "api-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-kotlin-geotools-jupyter" },
+    { "name": "isolatedFrame", "value": "" }
   ],
   "repositories": [
     "https://repo.osgeo.org/repository/release"
   ],
   "dependencies": [
-    "org.jetbrains.lets-plot:lets-plot-kotlin-geotools:$api",
-    "org.geotools:gt-geojson:$gt"
+    "org.jetbrains.lets-plot:lets-plot-kotlin-geotools-jupyter:$api"
   ]
 }

--- a/lets-plot-gt.json
+++ b/lets-plot-gt.json
@@ -13,8 +13,5 @@
   "dependencies": [
     "org.jetbrains.lets-plot:lets-plot-kotlin-geotools:$api",
     "org.geotools:gt-geojson:$gt"
-  ],
-  "imports": [
-    "org.jetbrains.letsPlot.toolkit.geotools.toSpatialDataset"
   ]
 }

--- a/lets-plot.json
+++ b/lets-plot.json
@@ -2,19 +2,11 @@
   "description": "Kotlin API for Lets-Plot: multiplatform plotting library based on Grammar of Graphics",
   "properties": [
     { "name": "api", "value": "4.8.0" },
-    { "name": "api-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-kotlin-kernel" },
-    { "name": "lib", "value": "4.4.1" },
-    { "name": "lib-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-common" },
-    { "name": "js", "value": "4.4.1" },
-    { "name": "lib-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-common" },
+    { "name": "api-renovate-hint", "value": "update: package=org.jetbrains.lets-plot:lets-plot-kotlin-jupyter" },
     { "name": "isolatedFrame", "value": "" }
   ],
   "link": "https://github.com/JetBrains/lets-plot-kotlin",
   "dependencies": [
-    "org.jetbrains.lets-plot:lets-plot-kotlin-kernel:$api",
-    "org.jetbrains.lets-plot:lets-plot-common:$lib",
-    "org.jetbrains.lets-plot:platf-awt-jvm:$lib",
-    "org.jetbrains.lets-plot:lets-plot-image-export:$lib",
-    "io.github.microutils:kotlin-logging-jvm:2.0.5"
+    "org.jetbrains.lets-plot:lets-plot-kotlin-jupyter:$api"
   ]
 }

--- a/lets-plot.json
+++ b/lets-plot.json
@@ -16,43 +16,5 @@
     "org.jetbrains.lets-plot:platf-awt-jvm:$lib",
     "org.jetbrains.lets-plot:lets-plot-image-export:$lib",
     "io.github.microutils:kotlin-logging-jvm:2.0.5"
-  ],
-  "imports": [
-    "org.jetbrains.letsPlot.*",
-    "org.jetbrains.letsPlot.geom.*",
-    "org.jetbrains.letsPlot.geom.extras.*",
-    "org.jetbrains.letsPlot.stat.*",
-    "org.jetbrains.letsPlot.label.*",
-    "org.jetbrains.letsPlot.scale.*",
-    "org.jetbrains.letsPlot.facet.*",
-    "org.jetbrains.letsPlot.sampling.*",
-    "org.jetbrains.letsPlot.export.*",
-    "org.jetbrains.letsPlot.tooltips.*",
-    "org.jetbrains.letsPlot.annotations.*",
-    "org.jetbrains.letsPlot.themes.*",
-    "org.jetbrains.letsPlot.font.*",
-    "org.jetbrains.letsPlot.coord.*",
-    "org.jetbrains.letsPlot.pos.*",
-    "org.jetbrains.letsPlot.bistro.corr.*",
-    "org.jetbrains.letsPlot.bistro.qq.*",
-    "org.jetbrains.letsPlot.bistro.joint.*",
-    "org.jetbrains.letsPlot.bistro.residual.*",
-    "org.jetbrains.letsPlot.bistro.waterfall.*",
-    "org.jetbrains.letsPlot.intern.toSpec",
-    "org.jetbrains.letsPlot.spatial.SpatialDataset"
-  ],
-  "init": [
-    "import org.jetbrains.letsPlot.LetsPlot",
-    "import org.jetbrains.letsPlot.frontend.NotebookFrontendContext",
-    "val isolatedFrameParam = if(\"$isolatedFrame\".isNotEmpty()) \"$isolatedFrame\".toBoolean() else null",
-    "val frontendContext = LetsPlot.setupNotebook(\"$js\", isolatedFrameParam) {DISPLAY(HTML(it))}",
-    "LetsPlot.apiVersion = \"$api\"",
-    "// Load library JS",
-    "DISPLAY(HTML(frontendContext.getConfigureHtml()))"
-  ],
-  "renderers": {
-    "org.jetbrains.letsPlot.intern.Plot": "HTML(frontendContext.getHtml($it as org.jetbrains.letsPlot.intern.Plot))",
-    "org.jetbrains.letsPlot.intern.figure.SubPlotsFigure": "HTML(frontendContext.getHtml($it as org.jetbrains.letsPlot.intern.figure.SubPlotsFigure))",
-    "org.jetbrains.letsPlot.GGBunch": "HTML(frontendContext.getHtml($it as org.jetbrains.letsPlot.GGBunch))"
-  }
+  ]
 }


### PR DESCRIPTION
Remove init/imports/renders part from Lets-Plot descriptors. They've been moved to Integration in Lets-Plot Kotlin. 

 **A Lets-Plot Kotlin release with these changes is required before we can merge!**