### PR TITLE
Ready dataframe.json for dataframe-jupyter module at v1.0+

### DIFF
--- a/dataframe.json
+++ b/dataframe.json
@@ -5,6 +5,9 @@
     { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:dataframe" }
   ],
   "link": "https://github.com/Kotlin/dataframe",
+  "init": [
+    "if (!\"$v\".startsWith('0')) USE { dependencies(\"org.jetbrains.kotlinx:dataframe-jupyter:$v\") }"
+  ],
   "dependencies": [
     "org.jetbrains.kotlinx:dataframe:$v"
   ],


### PR DESCRIPTION
## Description

Adds conditional statement to dataframe descriptor, allowing it to handle the integration being in `dataframe` before version 1.0 and in `dataframe-jupyter` after 1.0.

Related to https://github.com/Kotlin/dataframe/pull/1095

## Type of change

- [ ] Adding a new library descriptor
- [ ] Fixing an error in an existing descriptor
- [x] Updating an outdated descriptor
- [ ] Updating the library version