### PR TITLE
Kc25 as default?

### DIFF
--- a/dataframe.json
+++ b/dataframe.json
@@ -1,7 +1,7 @@
 {
   "description": "Kotlin framework for structured data processing",
   "properties": [
-    { "name": "v", "value": "1.0.0-Beta2" },
+    { "name": "v", "value": "1.0.0-dev-7089" },
     { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:dataframe" }
   ],
   "link": "https://github.com/Kotlin/dataframe",

--- a/kandy-echarts.json
+++ b/kandy-echarts.json
@@ -1,7 +1,7 @@
 {
   "description": "Kotlin plotting DSL for Apache ECharts",
   "properties": [
-    { "name": "kandyVersion", "value": "0.8.0" },
+    { "name": "kandyVersion", "value": "0.8.1-dev-67" },
     { "name": "kandyVersion-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kandy-echarts" }
   ],
   "link": "https://github.com/Kotlin/kandy",

--- a/kandy-geo.json
+++ b/kandy-geo.json
@@ -1,9 +1,9 @@
 {
   "description": "Geo extensions for Kandy and Kotlin Dataframe",
   "properties": [
-    { "name": "kandyVersion", "value": "0.8.0" },
+    { "name": "kandyVersion", "value": "0.8.1-dev-67" },
     { "name": "kandyVersion-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kandy-geo" },
-    { "name": "dataframeVersion", "value": "0.15.0" },
+    { "name": "dataframeVersion", "value": "1.0.0-dev-7089" },
     { "name": "dataframeVersion-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:dataframe-geo" }
   ],
   "link": "https://github.com/Kotlin/kandy",

--- a/kandy.json
+++ b/kandy.json
@@ -1,9 +1,9 @@
 {
   "description": "Kotlin plotting DSL for Lets-Plot",
   "properties": [
-    { "name": "kandyVersion", "value": "0.8.0" },
+    { "name": "kandyVersion", "value": "0.8.1-dev-67" },
     { "name": "kandyVersion-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:kandy-lets-plot" },
-    { "name": "statsVersion", "value": "0.4.0" }
+    { "name": "statsVersion", "value": "0.4.2-dev-2" }
   ],
   "link": "https://github.com/Kotlin/kandy",
   "repositories": [


### PR DESCRIPTION
setting default version for dataframe and kandy for KotlinConf 2025. This is on par with DF 1.0.0-Beta2 but takes https://github.com/Kotlin/dataframe/issues/1116 into account.

Currently the default versions (since https://github.com/Kotlin/kotlin-jupyter-libraries/pull/506) are dataframe: 0.15.0, Kandy: 0.8.0

## Description

(Briefly describe the changes you made)

## Type of change

- [ ] Adding a new library descriptor
- [ ] Fixing an error in an existing descriptor
- [ ] Updating an outdated descriptor
- [x] Updating the library version