### PR TITLE
Downgrading dataframe.json back to 0.15.0

### DIFF
--- a/dataframe.json
+++ b/dataframe.json
@@ -1,7 +1,7 @@
 {
   "description": "Kotlin framework for structured data processing",
   "properties": [
-    { "name": "v", "value": "1.0.0-Beta2" },
+    { "name": "v", "value": "0.15.0" },
     { "name": "v-renovate-hint", "value": "update: package=org.jetbrains.kotlinx:dataframe" }
   ],
   "link": "https://github.com/Kotlin/dataframe",


### PR DESCRIPTION
## Description

Beta 2 has issues with min/max etc. and incompatibility with the latest stable version of Kandy.
This reverts the default behavior of %use dataframe back to version 0.15.0, which works fine with kandy 0.8 and kandy-geo.

To use something like DataFrame Beta2, you can use the @kc25 descriptor, so %use dataframe%kc25, kandy@kc25, kandy-geo@kc25. This will fetch the right dev-descriptors



## Type of change

- [ ] Adding a new library descriptor
- [ ] Fixing an error in an existing descriptor
- [ ] Updating an outdated descriptor
- [x] Updating the library version