### PR TITLE
Add skainet-notebook 0.22.1 library descriptor

### DIFF
--- a/skainet-notebook.json
+++ b/skainet-notebook.json
@@ -1,0 +1,11 @@
+{
+  "description": "SKaiNET: Kotlin-native deep learning framework with SIMD-accelerated CPU kernels, GGUF/ONNX/SafeTensors loaders, and StableHLO compilation",
+  "properties": [
+    { "name": "v", "value": "0.22.1" },
+    { "name": "v-renovate-hint", "value": "update: package=sk.ainet.app:kotlin-notebook" }
+  ],
+  "link": "https://github.com/SKaiNET-developers/skainet-notebook",
+  "dependencies": [
+    "sk.ainet.app:kotlin-notebook:$v"
+  ]
+}


### PR DESCRIPTION
**SKaiNET Notebook** is a Kotlin Notebook integration of **SKaiNET** (https://github.com/SKaiNET-developers/SKaiNET), a Kotlin-native deep learning framework.

The notebook artifact, `sk.ainet.app:kotlin-notebook`, provides a `JupyterIntegration` class that is discovered through `META-INF/kotlin-jupyter-libraries/libraries.json`.

Because the integration is already included on the classpath, the library descriptor only needs to declare the description, link, properties, and Maven Central coordinate. Imports, renderers, the ready banner, and the SIMD availability check are all registered by the bundled integration class.


Verified before submission:
  - kotlin-notebook-0.22.1.jar HTTP 200 on repo1.maven.org
  - maven-metadata.xml declares 0.22.1 as both <latest> and <release>
  - JSON is well-formed (python3 -m json.tool) and ASCII-only

We will add more public samples showacing frameworks's capability into the repo itself soon. 